### PR TITLE
fix(auth): read the SSR session in-process (GRX-3)

### DIFF
--- a/app/components/PasskeyPrompt.vue
+++ b/app/components/PasskeyPrompt.vue
@@ -50,27 +50,25 @@
 
   const show = ref(false)
   const loading = ref(false)
-
-  // Server-side passkey check with useState for SSR (used by PasskeyPrompt component)
-  const userHasPasskeys = useState("user-has-passkeys", () => false)
-
-  // Only check if user is authenticated
-  if (user.value) {
-    await callOnce(async () => {
-      try {
-        const passkeys = await client.passkey.listUserPasskeys()
-        userHasPasskeys.value = Array.isArray(passkeys.data) && passkeys.data.length > 0
-      } catch (error) {
-        console.warn("Server-side passkey check failed:", error)
-      }
-    })
-  }
+  const hasPasskeys = ref(false)
 
   // Check if WebAuthn is supported
   const isWebAuthnSupported = computed(() => {
     if (typeof window === "undefined") return false
     return !!(window.PublicKeyCredential && navigator.credentials?.create)
   })
+
+  const fetchHasPasskeys = async (): Promise<boolean> => {
+    if (!user.value) return false
+
+    try {
+      const passkeys = await client.passkey.listUserPasskeys()
+      return Array.isArray(passkeys.data) && passkeys.data.length > 0
+    } catch (error) {
+      console.warn("Passkey check failed:", error)
+      return false
+    }
+  }
 
   // Complete decision logic for showing prompt
   const shouldShowPrompt = async (): Promise<boolean> => {
@@ -94,7 +92,10 @@
 
   // Initialize visibility with comprehensive async logic
   onMounted(async () => {
-    if (!isWebAuthnSupported.value || !userHasPasskeys.value) return
+    if (!isWebAuthnSupported.value) return
+
+    hasPasskeys.value = await fetchHasPasskeys()
+    if (!hasPasskeys.value) return
 
     try {
       const shouldShow = await shouldShowPrompt()
@@ -135,9 +136,7 @@
       // Mark as completed (updates both localStorage and server-side state)
       markPasskeySetup()
 
-      // Update useState to reflect new passkey
-      const ssrPasskeys = useState<boolean | null>("user-has-passkeys")
-      ssrPasskeys.value = true
+      hasPasskeys.value = true
     } catch (error) {
       console.error("Passkey setup failed:", error)
 

--- a/app/components/PasskeyPrompt.vue
+++ b/app/components/PasskeyPrompt.vue
@@ -50,7 +50,6 @@
 
   const show = ref(false)
   const loading = ref(false)
-  const hasPasskeys = ref(false)
 
   // Check if WebAuthn is supported
   const isWebAuthnSupported = computed(() => {
@@ -94,8 +93,8 @@
   onMounted(async () => {
     if (!isWebAuthnSupported.value) return
 
-    hasPasskeys.value = await fetchHasPasskeys()
-    if (!hasPasskeys.value) return
+    const hasPasskeys = await fetchHasPasskeys()
+    if (!hasPasskeys) return
 
     try {
       const shouldShow = await shouldShowPrompt()
@@ -135,8 +134,6 @@
 
       // Mark as completed (updates both localStorage and server-side state)
       markPasskeySetup()
-
-      hasPasskeys.value = true
     } catch (error) {
       console.error("Passkey setup failed:", error)
 

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -17,14 +17,9 @@ interface RuntimeAuthConfig {
 }
 
 export function useAuth() {
-  const url = useRequestURL()
-  const headers = import.meta.server ? { ...useRequestHeaders(), Origin: url.origin } : undefined
-
+  // Browser-only client: the SSR pass gets its session in-process, so no origin or
+  // forwarded headers are needed here.
   const client = createAuthClient({
-    baseURL: url.origin,
-    fetchOptions: {
-      headers,
-    },
     plugins: [
       passkeyClient(),
       organizationClient({
@@ -49,21 +44,16 @@ export function useAuth() {
   const loggedIn = computed(() => !!session.value)
 
   const fetchSession = async () => {
-    // Plugin already loaded session on server - skip HTTP request
-    if (import.meta.server && session.value !== null) {
+    if (import.meta.server) {
       return { session: session.value, user: user.value }
     }
 
     if (sessionFetching.value) {
-      console.log("already fetching session")
       return
     }
+
     sessionFetching.value = true
-    const { data } = await client.getSession({
-      fetchOptions: {
-        headers,
-      },
-    })
+    const { data } = await client.getSession()
     session.value = data?.session || null
     user.value = data?.user || null
     sessionFetching.value = false

--- a/app/composables/usePermissions.ts
+++ b/app/composables/usePermissions.ts
@@ -1,4 +1,4 @@
-type Role = "publisher" | "public_talk_coordinator" | "boe_coordinator" | "admin"
+type Role = "publisher" | "public_talk_coordinator" | "boe_coordinator" | "admin" | "owner"
 
 export function usePermissions() {
   const { user } = useAuth()

--- a/app/composables/usePermissions.ts
+++ b/app/composables/usePermissions.ts
@@ -1,7 +1,8 @@
 type Role = "publisher" | "public_talk_coordinator" | "boe_coordinator" | "admin"
 
 export function usePermissions() {
-  const { user, client } = useAuth()
+  const { user } = useAuth()
+  const requestFetch = useRequestFetch()
   const role = useState<Role>("permissions:role", () => "publisher")
   const permissionCache = useState<Map<string, boolean>>("permissions:cache", () => new Map())
   const isLoading = useState<boolean>("permissions:loading", () => false)
@@ -20,62 +21,11 @@ export function usePermissions() {
 
     isLoading.value = true
     try {
-      const { data: activeMember } = await client.organization.getActiveMember()
+      // requestFetch forwards the session cookie, which plain $fetch drops during SSR.
+      const permissionMap = await requestFetch("/api/permissions/me")
 
-      if (activeMember?.role) {
-        role.value = activeMember.role as Role
-      } else {
-        role.value = "publisher"
-      }
-
-      const permissionsToCheck = [
-        { key: "speakers:list", permissions: { speakers: ["list"] } },
-        { key: "speakers:create", permissions: { speakers: ["create"] } },
-        { key: "speakers:update", permissions: { speakers: ["update"] } },
-        { key: "speakers:archive", permissions: { speakers: ["archive"] } },
-        { key: "talks:create", permissions: { talks: ["create"] } },
-        { key: "talks:update", permissions: { talks: ["update"] } },
-        { key: "talks:archive", permissions: { talks: ["archive"] } },
-        { key: "talks:flag", permissions: { talks: ["flag"] } },
-        {
-          key: "weekend_meetings:schedule_public_talks",
-          permissions: { weekend_meetings: ["schedule_public_talks"] },
-        },
-        {
-          key: "weekend_meetings:schedule_rest",
-          permissions: { weekend_meetings: ["schedule_rest"] },
-        },
-        { key: "weekend_meetings:list", permissions: { weekend_meetings: ["list"] } },
-        {
-          key: "weekend_meetings:list_history",
-          permissions: { weekend_meetings: ["list_history"] },
-        },
-        {
-          key: "weekend_meetings:manage_exceptions",
-          permissions: { weekend_meetings: ["manage_exceptions"] },
-        },
-        { key: "publishers:list", permissions: { publishers: ["list"] } },
-        { key: "publishers:create", permissions: { publishers: ["create"] } },
-        { key: "publishers:update", permissions: { publishers: ["update"] } },
-        { key: "publishers:link_to_user", permissions: { publishers: ["link_to_user"] } },
-      ]
-
-      // Admin users have all permissions
-      if (role.value === "admin") {
-        for (const check of permissionsToCheck) {
-          permissionCache.value.set(check.key, true)
-        }
-      } else {
-        // Non-admin users need to check permissions via API
-        for (const check of permissionsToCheck) {
-          const response = await client.organization.hasPermission({
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            permissions: check.permissions as any,
-          })
-
-          permissionCache.value.set(check.key, response.data?.success ?? false)
-        }
-      }
+      role.value = permissionMap.role as Role
+      permissionCache.value = new Map(Object.entries(permissionMap.permissions))
 
       isFetched.value = true
     } catch (error) {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,23 +29,9 @@
   })
 
   const { t } = useI18n()
-  const { user, client } = useAuth()
+  const { user } = useAuth()
 
   const passkeyPromptRef = ref()
-  const hasPasskeys = useState<boolean>("user-has-passkeys", () => false)
-
-  onMounted(async () => {
-    // Client-only: Check for passkeys after hydration
-    if (!user.value) return
-
-    try {
-      const passkeys = await client.passkey.listUserPasskeys()
-      hasPasskeys.value = Array.isArray(passkeys) && passkeys.length > 0
-    } catch (error) {
-      console.warn("Passkey check failed:", error)
-      hasPasskeys.value = false
-    }
-  })
 
   useSeoPage("dashboard")
 </script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -2,7 +2,7 @@
   <div>
     <div
       class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
-      <div class="relative max-w-md w-full space-y-8">
+      <div class="max-w-md w-full space-y-8">
         <div :class="{ 'pointer-events-none opacity-50': sessionFetching }">
           <AuthForm
             ref="authFormRef"
@@ -12,14 +12,6 @@
             @forgot-password="handleForgotPassword" />
         </div>
       </div>
-    </div>
-    <!-- Loading overlay -->
-    <div
-      v-if="sessionFetching || overlayInitialState || loggedIn"
-      class="absolute inset-0 flex items-center justify-center bg-black/50! w-full h-full">
-      <UIcon
-        name="i-heroicons-arrow-path"
-        class="size-8 animate-spin text-primary" />
     </div>
   </div>
 </template>
@@ -33,14 +25,8 @@
     },
   })
 
-  const { signIn, fetchSession, sessionFetching, loggedIn } = useAuth()
+  const { signIn, fetchSession, sessionFetching } = useAuth()
   const authFormRef = ref()
-  const overlayInitialState = useState("overlayInitialState", () => true)
-  onMounted(() => {
-    nextTick(() => {
-      overlayInitialState.value = false
-    })
-  })
 
   const handleSignIn = async (credentials: { email: string; password: string }) => {
     if (!authFormRef.value) return

--- a/app/plugins/01.auth-init.server.ts
+++ b/app/plugins/01.auth-init.server.ts
@@ -2,6 +2,11 @@ export default defineNuxtPlugin(async () => {
   const event = useRequestEvent()
   if (!event) return
 
-  const { fetchSession } = useAuth()
-  await fetchSession()
+  const { session, user } = useAuth()
+  // The app bundle cannot import server utils, so Better Auth is reached through the
+  // request context instead of over HTTP.
+  const serverSession = await event.context.readSession?.()
+
+  session.value = serverSession?.session ?? null
+  user.value = serverSession?.user ?? null
 })

--- a/server/api/permissions/me.get.ts
+++ b/server/api/permissions/me.get.ts
@@ -1,20 +1,24 @@
-import type { H3Event } from "h3"
 import { defineEndpoint } from "../../utils/define-endpoint"
-import type { PermissionsMap } from "#shared/types/permissions"
-import { statement } from "#shared/utils/permissions/declare"
+import {
+  statement,
+  publisher,
+  public_talk_coordinator,
+  boe_coordinator,
+} from "#shared/utils/permissions/declare"
 
 interface PermissionMap {
   role: string
   permissions: Record<string, boolean>
 }
 
-interface PermissionCheck {
-  key: string
-  permissions: PermissionsMap
-}
-
 const ROLE_WITHOUT_MEMBERSHIP = "publisher"
 const UNRESTRICTED_ROLES = ["admin", "owner"]
+
+const ROLE_STATEMENTS: Record<string, Record<string, readonly string[]>> = {
+  publisher: publisher.statements,
+  public_talk_coordinator: public_talk_coordinator.statements,
+  boe_coordinator: boe_coordinator.statements,
+}
 
 export default defineEndpoint({
   auth: true,
@@ -31,36 +35,32 @@ export default defineEndpoint({
       return { role: member.role, permissions: everyPermissionSetTo(true) }
     }
 
-    return { role: member.role, permissions: await grantedPermissions(event) }
+    return { role: member.role, permissions: grantedPermissions(member.role) }
   },
 })
 
 function everyPermissionSetTo(granted: boolean): Record<string, boolean> {
-  return Object.fromEntries(declaredChecks().map(check => [check.key, granted]))
+  return Object.fromEntries(declaredKeys().map(key => [key, granted]))
 }
 
-async function grantedPermissions(event: H3Event): Promise<Record<string, boolean>> {
-  const granted: Record<string, boolean> = {}
+// Answered from the static declaration: asking better-auth per permission costs one D1
+// round trip each, serialized inside a single SSR render.
+function grantedPermissions(role: string): Record<string, boolean> {
+  const granted = grantedKeys(role)
 
-  for (const check of declaredChecks()) {
-    const result = await serverAuth().api.hasPermission({
-      headers: event.headers,
-      body: { permissions: check.permissions },
-    })
-
-    granted[check.key] = result?.success === true
-  }
-
-  return granted
+  return Object.fromEntries(declaredKeys().map(key => [key, granted.has(key)]))
 }
 
-function declaredChecks(): PermissionCheck[] {
-  const declaration: Record<string, readonly string[]> = statement
+function grantedKeys(role: string): Set<string> {
+  return new Set(permissionKeysOf(ROLE_STATEMENTS[role] ?? {}))
+}
 
+function declaredKeys(): string[] {
+  return permissionKeysOf(statement)
+}
+
+function permissionKeysOf(declaration: Record<string, readonly string[]>): string[] {
   return Object.entries(declaration).flatMap(([resource, actions]) =>
-    actions.map(action => ({
-      key: `${resource}:${action}`,
-      permissions: { [resource]: [action] } as PermissionsMap,
-    }))
+    actions.map(action => `${resource}:${action}`)
   )
 }

--- a/server/api/permissions/me.get.ts
+++ b/server/api/permissions/me.get.ts
@@ -1,0 +1,66 @@
+import type { H3Event } from "h3"
+import { defineEndpoint } from "../../utils/define-endpoint"
+import type { PermissionsMap } from "#shared/types/permissions"
+import { statement } from "#shared/utils/permissions/declare"
+
+interface PermissionMap {
+  role: string
+  permissions: Record<string, boolean>
+}
+
+interface PermissionCheck {
+  key: string
+  permissions: PermissionsMap
+}
+
+const ROLE_WITHOUT_MEMBERSHIP = "publisher"
+const UNRESTRICTED_ROLES = ["admin", "owner"]
+
+export default defineEndpoint({
+  auth: true,
+  handler: async (event): Promise<PermissionMap> => {
+    const member = await serverAuth().api.getActiveMember({
+      headers: event.headers,
+    })
+
+    if (!member) {
+      return { role: ROLE_WITHOUT_MEMBERSHIP, permissions: everyPermissionSetTo(false) }
+    }
+
+    if (UNRESTRICTED_ROLES.includes(member.role)) {
+      return { role: member.role, permissions: everyPermissionSetTo(true) }
+    }
+
+    return { role: member.role, permissions: await grantedPermissions(event) }
+  },
+})
+
+function everyPermissionSetTo(granted: boolean): Record<string, boolean> {
+  return Object.fromEntries(declaredChecks().map(check => [check.key, granted]))
+}
+
+async function grantedPermissions(event: H3Event): Promise<Record<string, boolean>> {
+  const granted: Record<string, boolean> = {}
+
+  for (const check of declaredChecks()) {
+    const result = await serverAuth().api.hasPermission({
+      headers: event.headers,
+      body: { permissions: check.permissions },
+    })
+
+    granted[check.key] = result?.success === true
+  }
+
+  return granted
+}
+
+function declaredChecks(): PermissionCheck[] {
+  const declaration: Record<string, readonly string[]> = statement
+
+  return Object.entries(declaration).flatMap(([resource, actions]) =>
+    actions.map(action => ({
+      key: `${resource}:${action}`,
+      permissions: { [resource]: [action] } as PermissionsMap,
+    }))
+  )
+}

--- a/server/middleware/auth-session.ts
+++ b/server/middleware/auth-session.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(event => {
+  // Handed over rather than resolved: this runs on every request, and only a page render
+  // needs the session here — API handlers read it themselves.
+  event.context.readSession = () => readSession(event)
+})

--- a/server/utils/auth-session.ts
+++ b/server/utils/auth-session.ts
@@ -1,0 +1,17 @@
+import type { H3Event } from "h3"
+import { appendResponseHeader } from "h3"
+
+export async function readSession(event: H3Event) {
+  const { headers, response } = await serverAuth().api.getSession({
+    headers: event.headers,
+    returnHeaders: true,
+  })
+
+  // Better Auth ships no Nuxt cookie integration: a refreshed session returns its
+  // Set-Cookie on these headers, and nothing carries it to the browser unless we copy it.
+  for (const cookie of headers.getSetCookie()) {
+    appendResponseHeader(event, "set-cookie", cookie)
+  }
+
+  return response
+}

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -57,16 +57,16 @@ function getBetterAuth() {
       passkey(),
     ],
     advanced: {
-      // A Secure cookie is dropped by the browser over the plain HTTP the local stack
-      // serves, so this follows the environment rather than being pinned on.
-      useSecureCookies: isProduction(),
-      defaultCookieAttributes: {
-        sameSite: "lax",
-        httpOnly: true,
-      },
+      // Off so the session cookie keeps its plain name: better-auth prefixes every cookie
+      // with "__Secure-" when this is on, which would orphan all live sessions.
+      useSecureCookies: false,
       cookies: {
         session_token: {
           name: AUTH_COOKIE_NAME,
+          attributes: {
+            secure: true,
+            httpOnly: true,
+          },
         },
       },
     },

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -12,6 +12,11 @@ import {
 import { AUTH_COOKIE_NAME } from "#shared/constants/cookies"
 import { member as memberTable } from "../database/auth-schema"
 
+// Pinned at the library's own defaults so an upgrade cannot move session lifetime silently.
+const SESSION_EXPIRES_IN = 60 * 60 * 24 * 7
+const SESSION_UPDATE_AGE = 60 * 60 * 24
+const SESSION_FRESH_AGE = 60 * 60 * 24
+
 let _auth: ReturnType<typeof getBetterAuth>
 
 export function serverAuth() {
@@ -52,18 +57,23 @@ function getBetterAuth() {
       passkey(),
     ],
     advanced: {
-      useSecureCookies: false,
+      // A Secure cookie is dropped by the browser over the plain HTTP the local stack
+      // serves, so this follows the environment rather than being pinned on.
+      useSecureCookies: isProduction(),
+      defaultCookieAttributes: {
+        sameSite: "lax",
+        httpOnly: true,
+      },
       cookies: {
         session_token: {
           name: AUTH_COOKIE_NAME,
-          attributes: {
-            secure: true,
-            httpOnly: true,
-          },
         },
       },
     },
     session: {
+      expiresIn: SESSION_EXPIRES_IN,
+      updateAge: SESSION_UPDATE_AGE,
+      freshAge: SESSION_FRESH_AGE,
       cookieCache: {
         enabled: true,
         maxAge: 300,

--- a/shared/types/event-context.d.ts
+++ b/shared/types/event-context.d.ts
@@ -1,0 +1,9 @@
+import type { Session, User } from "better-auth"
+
+declare module "h3" {
+  interface H3EventContext {
+    readSession?: () => Promise<{ session: Session; user: User } | null>
+  }
+}
+
+export {}

--- a/tests/fixtures/auth-fixtures.ts
+++ b/tests/fixtures/auth-fixtures.ts
@@ -6,7 +6,7 @@ type Role = "admin" | "publisher" | "public_talk_coordinator" | "boe_coordinator
 
 /**
  * Authenticates user with specified role and returns the page.
- * Handles login flow including waiting for hydration and redirect.
+ * Handles login flow including waiting for the post-login redirect.
  */
 export async function authenticateAs(page: Page, role: Role): Promise<void> {
   const user = testAccounts.users.find(u => u.role === role)
@@ -15,7 +15,6 @@ export async function authenticateAs(page: Page, role: Role): Promise<void> {
   }
 
   await page.goto("http://localhost:3000/login")
-  await page.waitForTimeout(5000)
 
   await page.getByTestId("auth-email-input").fill(user.email)
   await page.getByTestId("auth-password-input").fill(user.password)
@@ -24,7 +23,6 @@ export async function authenticateAs(page: Page, role: Role): Promise<void> {
   await submitButton.waitFor({ state: "visible" })
   await expect(submitButton).toBeEnabled()
   await submitButton.click()
-  await page.waitForTimeout(2000)
 
   await page.waitForURL("http://localhost:3000/user")
 }


### PR DESCRIPTION
Phase 1 of the VPS/PostgreSQL migration spec. First in a stacked chain — `feat/postgres-vps-migration` targets this branch.

## What changes

The SSR pass no longer makes an HTTP round trip to read its own session. `server/utils/auth-session.ts` calls `serverAuth().api.getSession({ returnHeaders: true })` in-process and forwards `Set-Cookie` onto the page response; a thin middleware exposes it lazily on `event.context`, and `app/plugins/01.auth-init.server.ts` fills the auth store from it.

With the session available during SSR, the two workarounds it forced go away: `GET /api/permissions/me` returns the whole permission map in one call instead of the client looping per key, and the login page drops the overlay that hid the SSR gap along with the fixture waits that masked it.

## Tasks

- `0001-ssr-in-process-session` — SSR reads the session in-process
- `0002-permission-map-endpoint` — permission map endpoint replaces the per-key loop
- `0003-login-overlay-and-fixture-waits` — remove the SSR-gap overlay and the waits that masked it

Spec: `docs/specs/2026-08-04-vps-postgres-migration.md` (§UI-1..4, API-1, CONFIG-2; D2, D3, D4, D6, D7)

## Review notes

Code review caught two things that were fixed before this landed:

- `useSecureCookies: isProduction()` would have renamed the production session cookie to `__Secure-zychlin-org-session`, logging every user out on the first deploy. Reverted to the previous shape, with the cookie's own `secure`/`httpOnly` attributes.
- The permission endpoint originally awaited `hasPermission()` once per declared key — 17 sequential calls, each with its own membership query, on every non-admin SSR render. It now resolves the map synchronously from the static role declarations in `shared/utils/permissions/declare.ts`.

## Validation

`pnpm lint` and `pnpm build` pass. E2E was not run — the baseline on `main` already fails locally for missing Playwright browsers and auth env vars.

Ticket: GRX-3
